### PR TITLE
Add config filter support to addon configuration

### DIFF
--- a/authelia/config.yaml
+++ b/authelia/config.yaml
@@ -18,6 +18,7 @@ options:
   domain: "exemple.com"
 schema:
   domain: str
+  config_filters: str?
   smtp_username: str?
   smtp_password: str?
   smtp_sender: str?

--- a/authelia/rootfs/etc/s6-overlay/s6-rc.d/authelia/run
+++ b/authelia/rootfs/etc/s6-overlay/s6-rc.d/authelia/run
@@ -6,4 +6,9 @@
 
 bashio::log.info "Starting Authelia...."
 
+# Support for https://www.authelia.com/configuration/methods/files/#file-filters.
+# For compatibility/stability reasons use the variable instead of the command-line argument:
+# "...the name of the CLI argument will change (we suggest using the environment variable which will not)"
+export X_AUTHELIA_CONFIG_FILTERS="$(bashio::config 'config_filters' '')"
+
 exec authelia --config /config/configuration.yml


### PR DESCRIPTION
Implements a new, unset-by-default, addon config option to let users enable support for Authelia's configuration file templateing.

This was tested in a fork of the addon using my own HAOS installation with debug logging applied:
```
time="2024-07-05T20:31:07-05:00" level=debug msg="Loaded Configuration Sources" files="[/config/configuration.yml]" filters="[template]"
```

Closes #5